### PR TITLE
Make visitor signup steps clearer

### DIFF
--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -1,6 +1,6 @@
 ---
 title: Visitor access - GovWifi
-description: Access GovWifi as a visitor to public sector organisations
+description: GovWifi access for non-public sector staff
 ---
 <div class="container">
   <%= partial "shared/support/breadcrumbs", locals: { page: "Connect to GovWifi as a visitor" } %>


### PR DESCRIPTION
Need to make clear distinction between the two steps involved to signup for GovWifi as a visitor